### PR TITLE
Bump org.owasp.dependencycheck from 7.4.1 to 7.4.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew clean build test jacocoTestReport sonarqube --info
+      - name: OWASP dependencyCheckAggregate
+        run: ./gradlew dependencyCheckAggregate --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("com.google.cloud.tools.jib") version "3.3.1" // https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin
     id("com.github.hierynomus.license-base") version "0.16.1"
     id("org.unbroken-dome.test-sets") version "4.0.0"
-    id("org.owasp.dependencycheck") version "7.4.1"
+    id("org.owasp.dependencycheck") version "7.4.4"
     id("com.github.ben-manes.versions") version "0.44.0"
     id("info.solidsoft.pitest") version "1.9.11"
 }


### PR DESCRIPTION
Bumps org.owasp.dependencycheck from 7.4.1 to 7.4.4.

---
updated-dependencies:
- dependency-name: org.owasp.dependencycheck dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>